### PR TITLE
Search api for wear items

### DIFF
--- a/server/Constants.py
+++ b/server/Constants.py
@@ -27,6 +27,7 @@ class WearItemTrackingEntry(BaseModel):
     item_id: int
     counter: int
     date: str
+    name: Optional[str]
 
 class WearItemTrackingSumEntity(BaseModel):
     item_id: int

--- a/server/api_server.py
+++ b/server/api_server.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import List, Optional
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
 
 from server.Constants import WearItem, WearItemTrackingEntry
 from server.wear_service import WearService
@@ -9,6 +10,14 @@ app = FastAPI()
 
 DB_NAME = "wear-tracker.db"
 wear_service = WearService(DB_NAME)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 async def home():
@@ -44,6 +53,13 @@ async def fetch_items_with_tracking():
     output = wear_service.fetch_wear_items_with_tracking()
     return output
 
+@app.get("/v1/search")
+async def search_wear_items(name: Optional[str] = Query(None, description="Search terms"),
+                            color: Optional[str] = Query(None, description="Color of item")):
+    print(f"In search_wear_items for {name}...{color}")
+    query_param_dict = {'name': name, 'color': color}
+    output = wear_service.search_wear_items(query_param_dict)
+    return output
 
 if __name__ == "__main__":
     import uvicorn

--- a/server/database_handler.py
+++ b/server/database_handler.py
@@ -106,7 +106,8 @@ class DatabaseHandler:
 
     def fetch_wear_item_tracking(self, item: int):
         cursor = self.conn.cursor()
-        select_query = f"SELECT * from {DbConstants.WEAR_ITEM_TRACKING} WHERE item_id = {item}"
+        select_query = (f"SELECT wit.*, wi.name from {DbConstants.WEAR_ITEM_TRACKING} as wit inner join {DbConstants.WEAR_ITEM} as wi"
+                        f" on wi.id == wit.item_id WHERE item_id = {item}")
         cursor.execute(select_query)
         rows = cursor.fetchall()
         cursor.close()
@@ -116,6 +117,23 @@ class DatabaseHandler:
         select_query = (f"select wi.id, wi.name, wi.type, wi.active, sum(wit.counter) as count from {DbConstants.WEAR_ITEM_TRACKING} as wit right join {DbConstants.WEAR_ITEM} as wi"
                         f" on wi.id == wit.item_id group by wi.id, wi.name, wi.type, wi.active")
         cursor = self.conn.cursor()
+        cursor.execute(select_query)
+        rows = cursor.fetchall()
+        cursor.close()
+        return rows
+
+    def search_wear_items(self, query_param):
+        select_query = f"select * from {DbConstants.WEAR_ITEM} where "
+        need_and = False
+        if query_param['name'] is not None:
+            select_query += f"name like '%{query_param['name']}%' "
+            need_and = True
+        elif query_param['color'] is not None:
+            if need_and:
+                select_query += " and "
+            select_query += f" color like '%{query_param['color']}%' "
+        cursor = self.conn.cursor()
+        print(f"HERE search query:: {select_query}")
         cursor.execute(select_query)
         rows = cursor.fetchall()
         cursor.close()

--- a/server/utils.py
+++ b/server/utils.py
@@ -16,7 +16,7 @@ def convert_to_wear_item_tracking(items):
     resp = []
     for item in items:
         print(f"IN convert_to_wear_item_tracking:: {item}")
-        resp.append(WearItemTrackingEntry(item_id=item[1], counter=item[2], date=item[3]))
+        resp.append(WearItemTrackingEntry(item_id=item[1], counter=item[2], date=item[3], name=item[4]))
     return resp
 
 def convert_to_wear_item_tracking_sum(items):

--- a/server/wear_service.py
+++ b/server/wear_service.py
@@ -35,3 +35,10 @@ class WearService:
         formatted_output = convert_to_wear_item_tracking_sum(output)
         return formatted_output
 
+    def search_wear_items(self, query_param_dict):
+        output = self.database_conn.search_wear_items(query_param_dict)
+        formatted_output = convert_to_wear_item(output)
+        return formatted_output
+
+
+


### PR DESCRIPTION
Changes:
- Adding an api to search wear items.
- Supports query on name and color. Does a `like '%search_term%'` type query. Should be fine for small amount of data. (Scope for optimization)